### PR TITLE
Fix typos

### DIFF
--- a/doc/guides/FeatureGuideForSolidity.md
+++ b/doc/guides/FeatureGuideForSolidity.md
@@ -95,7 +95,7 @@ In this guide, we will list all Solidity language features and briefly summarize
 - Modifier declaration and usage
   - Keyword `modifier` is not yet supported.
   - Developers should extend their modifier logic into function body directly
-- Multiple contracts declartion.
+- Multiple contracts declaration.
   - Developers can declare only one contract in a single file.
 - Contract inheritance
   - Keyword `is` is not yet supported.

--- a/doc/guides/FeatureGuideForYul.md
+++ b/doc/guides/FeatureGuideForYul.md
@@ -32,7 +32,7 @@ If you want to execute ewasm compiled from Yul, refer to the [DevGuide](DevGuide
 
 Below will describe some under implement language features.
 
-|                                             feature                                              |                           item                           |         exmaple         |
+|                                             feature                                              |                           item                           |         example         |
 |--------------------------------------------------------------------------------------------------|----------------------------------------------------------|-------------------------|
 | statement                                                                                        | Switch with string literal                               | case ""                 |
 | [Yul built-in function](https://solidity.readthedocs.io/en/v0.5.12/yul.html#low-level-functions) | logic not/and/or/xor <br>(conflict with inline assembly) |                         |

--- a/test/solidity/compilationTests/corion/ico.sol
+++ b/test/solidity/compilationTests/corion/ico.sol
@@ -198,7 +198,7 @@ contract ico is safeMath {
 
     function setICOEthPrice(uint256 value) external {
         /*
-            Setting of the ICO ETC USD rates which can only be calle by a pre-defined address.
+            Setting of the ICO ETC USD rates which can only be callee by a pre-defined address.
             After this function is completed till the call of the next function (which is at least an exchangeRateDelay array) this rate counts.
             With this process avoiding the sudden rate changes.
 

--- a/test/solidity/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
+++ b/test/solidity/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol
@@ -151,7 +151,7 @@ contract LMSRMarketMaker is MarketMaker {
 
         // finally, if the distribution looks like [BIG, tiny, tiny...], using a
         // BIG offset will cause the tiny quantities to go really negative
-        // causing the associated exponentials to vanish.
+        // causing the associated exponential to vanish.
 
         int maxQuantity = Math.max(netOutcomeTokensSold);
         require(logN >= 0 && int(funding) >= 0);

--- a/test/solidity/diag/enum.sol
+++ b/test/solidity/diag/enum.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: not sh -c '%soll %s; exit $?' |& FileCheck %s
-// The shell prevents SIGABRT from propogating to `not`
+// The shell prevents SIGABRT from propagating to `not`
 
 pragma solidity ^0.5.0;
 

--- a/test/solidity/diag/invalidName.sol
+++ b/test/solidity/diag/invalidName.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: not sh -c '%soll %s; exit $?' |& FileCheck %s
-// The shell prevents SIGABRT from propogating to `not`
+// The shell prevents SIGABRT from propagating to `not`
 
 pragma solidity ^0.5.0;
 

--- a/test/solidity/diag/multipleFallbacks.sol
+++ b/test/solidity/diag/multipleFallbacks.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 // RUN: not sh -c '%soll %s; exit $?' |& FileCheck %s
-// The shell prevents SIGABRT from propogating to `not`
+// The shell prevents SIGABRT from propagating to `not`
 
 pragma solidity ^0.5.0;
 

--- a/utils/json/json.hpp
+++ b/utils/json/json.hpp
@@ -6975,7 +6975,7 @@ class binary_reader
 
     @return whether conversion completed
 
-    @note This function needs to respect the system's endianess, because
+    @note This function needs to respect the system's endianness, because
           bytes in CBOR, MessagePack, and UBJSON are stored in network order
           (big endian) and therefore need reordering on little endian systems.
     */
@@ -7113,7 +7113,7 @@ class binary_reader
     /// the number of characters read
     std::size_t chars_read = 0;
 
-    /// whether we can assume little endianess
+    /// whether we can assume little endianness
     const bool is_little_endian = little_endianess();
 
     /// the SAX parser
@@ -12554,7 +12554,7 @@ class binary_writer
     @tparam OutputIsLittleEndian Set to true if output data is
                                  required to be little endian
 
-    @note This function needs to respect the system's endianess, because bytes
+    @note This function needs to respect the system's endianness, because bytes
           in CBOR, MessagePack, and UBJSON are stored in network order (big
           endian) and therefore need reordering on little endian systems.
     */
@@ -12617,7 +12617,7 @@ class binary_writer
     }
 
   private:
-    /// whether we can assume little endianess
+    /// whether we can assume little endianness
     const bool is_little_endian = binary_reader<BasicJsonType>::little_endianess();
 
     /// the output

--- a/utils/unittests/catch.hpp
+++ b/utils/unittests/catch.hpp
@@ -10469,7 +10469,7 @@ namespace Catch {
             // Extracts the actual name part of an enum instance
             // In other words, it returns the Blue part of Bikeshed::Colour::Blue
             StringRef extractInstanceName(StringRef enumInstance) {
-                // Find last occurence of ":"
+                // Find last occurrence of ":"
                 size_t name_start = enumInstance.size();
                 while (name_start > 0 && enumInstance[name_start - 1] != ':') {
                     --name_start;


### PR DESCRIPTION
Hey,

This huge PR will fix : 

- 1 typo in `doc/guides/FeatureGuideForSolidity.md`
- 1 typo in `doc/guides/FeatureGuideForYul.md`
- 1 typo in `test/solidity/compilationTests/corion/ico.sol`
- 1 typo in `test/solidity/compilationTests/gnosis/MarketMakers/LMSRMarketMaker.sol`
- 1 typo in `test/solidity/diag/enum.sol`
- 1 typo in `test/solidity/diag/invalidName.sol`
- 1 typo in `test/solidity/diag/multipleFallbacks.sol`
- 4 typos in `utils/json/json.hpp`
- 1 typo in `utils/unittests/catch.hpp`



Ciao! :robot: