### PR TITLE
[CodeGen] Revert multiple source unit implementation

### DIFF
--- a/include/soll/Parse/ParseAST.h
+++ b/include/soll/Parse/ParseAST.h
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #pragma once
-#include "soll/AST/AST.h"
-#include <vector>
 
 namespace soll {
 
@@ -9,7 +7,7 @@ class ASTConsumer;
 class ASTContext;
 class Sema;
 
-std::vector<std::unique_ptr<SourceUnit>>
-ParseAST(Sema &S, const InputKind &Lang, bool PrintStats = false);
+void ParseAST(Sema &S, ASTConsumer &C, ASTContext &Ctx,
+              bool PrintStats = false);
 
 } // namespace soll

--- a/include/soll/Parse/Parser.h
+++ b/include/soll/Parse/Parser.h
@@ -35,7 +35,7 @@ class Parser {
 
 public:
   Parser(Lexer &TheLexer, Sema &Actions, DiagnosticsEngine &Diags);
-  std::vector<std::unique_ptr<SourceUnit>> parse();
+  std::unique_ptr<SourceUnit> parse();
   std::unique_ptr<SourceUnit> parseYul();
 
 private:
@@ -271,7 +271,7 @@ private:
 
   bool ExpectAndConsume(tok::TokenKind ExpectedTok,
                         unsigned Diag = diag::err_expected,
-                        llvm::StringRef DiagMsg = {});
+                        llvm::StringRef DiagMsg = "");
   bool ExpectAndConsumeSemi(unsigned DiagID = diag::err_expected);
 
 public:

--- a/include/soll/Sema/Sema.h
+++ b/include/soll/Sema/Sema.h
@@ -27,10 +27,12 @@ class Sema {
 
 public:
   Lexer &Lex;
+  ASTContext &Context;
+  ASTConsumer &Consumer;
   DiagnosticsEngine &Diags;
   SourceManager &SourceMgr;
 
-  Sema(Lexer &lexer);
+  Sema(Lexer &lexer, ASTContext &ctxt, ASTConsumer &consumer);
 
   DiagnosticBuilder Diag(SourceLocation Loc, unsigned DiagID);
 

--- a/lib/CodeGen/CGValue.h
+++ b/lib/CodeGen/CGValue.h
@@ -36,7 +36,7 @@ public:
 
   template <typename T>
   llvm::Value *load(T &Builder, CodeGenModule &CGM,
-                    llvm::StringRef Name = {}) const {
+                    llvm::StringRef Name = "") const {
     if (isTuple() || isSlot()) {
       return nullptr;
     }

--- a/lib/CodeGen/CodeGenAction.cpp
+++ b/lib/CodeGen/CodeGenAction.cpp
@@ -11,6 +11,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/Support/ToolOutputFile.h>
 #include <llvm/Transforms/Utils/Cloning.h>
+
 extern "C" {
 typedef void *BinaryenModuleRef;
 void BinaryenModuleDispose(BinaryenModuleRef module);
@@ -90,10 +91,6 @@ class BackendConsumer : public ASTConsumer {
   std::string InFile;
   std::unique_ptr<llvm::raw_pwrite_stream> AsmOutStream;
   ASTContext *Context;
-  llvm::LLVMContext &LLVMContext;
-  std::function<std::unique_ptr<llvm::raw_pwrite_stream>(
-      llvm::StringRef, BackendAction, llvm::StringRef)>
-      GetOutputStreamCallback;
 
   std::unique_ptr<CodeGenerator> Gen;
 
@@ -194,14 +191,12 @@ public:
   BackendConsumer(BackendAction Action, DiagnosticsEngine &Diags,
                   const CodeGenOptions &CodeGenOpts,
                   const TargetOptions &TargetOpts, const std::string &InFile,
-                  llvm::LLVMContext &C,
-                  std::function<std::unique_ptr<llvm::raw_pwrite_stream>(
-                      llvm::StringRef, BackendAction, llvm::StringRef)>
-                      GetOutputStreamCallback)
+                  std::unique_ptr<llvm::raw_pwrite_stream> OS,
+                  llvm::LLVMContext &C)
       : Action(Action), Diags(Diags), CodeGenOpts(CodeGenOpts),
-        TargetOpts(TargetOpts), InFile(InFile), AsmOutStream(nullptr),
-        Context(nullptr), LLVMContext(C),
-        GetOutputStreamCallback(GetOutputStreamCallback), Gen(nullptr) {}
+        TargetOpts(TargetOpts), InFile(InFile), AsmOutStream(std::move(OS)),
+        Context(nullptr),
+        Gen(CreateLLVMCodeGen(Diags, InFile, C, CodeGenOpts, TargetOpts)) {}
   llvm::Module *getModule() const { return Gen->getModule(); }
 
   CodeGenerator *getCodeGenerator() { return Gen.get(); }
@@ -209,19 +204,13 @@ public:
   void Initialize(ASTContext &Ctx) override {
     assert(!Context && "initialized multiple times");
     Context = &Ctx;
+
+    Gen->Initialize(Ctx);
   }
 
   void HandleSourceUnit(ASTContext &C, SourceUnit &S) override {
-    Gen = std::unique_ptr<CodeGenerator>(
-        CreateLLVMCodeGen(Diags, InFile, LLVMContext, CodeGenOpts, TargetOpts));
-    Gen->Initialize(*Context);
     Gen->HandleSourceUnit(C, S);
 
-    auto Str = S.getNodes().back()->getName().str() + ".solltmp";
-    AsmOutStream = GetOutputStreamCallback(InFile, Action, Str);
-    if (Action != BackendAction::EmitNothing && !AsmOutStream) {
-      return;
-    }
     // Silently ignore if we weren't initialized for some reason.
     if (!getModule()) {
       return;
@@ -271,11 +260,41 @@ CodeGenAction::CodeGenAction(BackendAction Action, llvm::LLVMContext *VMContext)
                                : std::make_unique<llvm::LLVMContext>()),
       VMContext(VMContext ? VMContext : OwnedVMContext.get()) {}
 
+static std::unique_ptr<llvm::raw_pwrite_stream>
+GetOutputStream(CompilerInstance &CI, llvm::StringRef InFile,
+                BackendAction Action) {
+  switch (Action) {
+  case BackendAction::EmitAssembly:
+    return CI.createDefaultOutputFile(false, InFile, "s");
+  case BackendAction::EmitLL:
+    return CI.createDefaultOutputFile(false, InFile, "ll");
+  case BackendAction::EmitBC:
+    return CI.createDefaultOutputFile(true, InFile, "bc");
+  case BackendAction::EmitNothing:
+    return nullptr;
+  case BackendAction::EmitMCNull:
+    return CI.createNullOutputFile();
+  case BackendAction::EmitObj:
+    return CI.createDefaultOutputFile(true, InFile, "o");
+  case BackendAction::EmitWasm:
+    return CI.createDefaultOutputFile(true, InFile, "wasm");
+  }
+
+  llvm_unreachable("Invalid action!");
+}
+
 std::unique_ptr<ASTConsumer>
 CodeGenAction::CreateASTConsumer(CompilerInstance &CI, llvm::StringRef InFile) {
+  std::unique_ptr<llvm::raw_pwrite_stream> OS =
+      GetOutputStream(CI, InFile, Action);
+
+  if (Action != BackendAction::EmitNothing && !OS) {
+    return nullptr;
+  }
+
   return std::make_unique<BackendConsumer>(
       Action, CI.getDiagnostics(), CI.getCodeGenOpts(), CI.getTargetOpts(),
-      InFile, *VMContext, CI.GetOutputStreamFunc());
+      InFile, std::move(OS), *VMContext);
 }
 
 EmitAssemblyAction::EmitAssemblyAction(llvm::LLVMContext *VMContext)

--- a/lib/Frontend/CompilerInstance.cpp
+++ b/lib/Frontend/CompilerInstance.cpp
@@ -5,7 +5,6 @@
 #include "soll/Basic/DiagnosticIDs.h"
 #include "soll/Basic/FileManager.h"
 #include "soll/Basic/SourceManager.h"
-#include "soll/CodeGen/CodeGenAction.h"
 #include "soll/Frontend/ASTConsumers.h"
 #include "soll/Frontend/CompilerInvocation.h"
 #include "soll/Frontend/FrontendAction.h"
@@ -15,7 +14,6 @@
 #include "soll/Lex/Lexer.h"
 #include "soll/Sema/Sema.h"
 #include <cassert>
-#include <functional>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/Support/Errc.h>
@@ -23,33 +21,6 @@
 #include <memory>
 
 namespace soll {
-
-std::function<std::unique_ptr<llvm::raw_pwrite_stream>(
-    llvm::StringRef, BackendAction, llvm::StringRef)>
-CompilerInstance::GetOutputStreamFunc() {
-  return
-      [&](llvm::StringRef InFile, BackendAction Action,
-          llvm::StringRef OutName) -> std::unique_ptr<llvm::raw_pwrite_stream> {
-        switch (Action) {
-        case BackendAction::EmitAssembly:
-          return createDefaultOutputFile(false, InFile, "s", OutName);
-        case BackendAction::EmitLL:
-          return createDefaultOutputFile(false, InFile, "ll", OutName);
-        case BackendAction::EmitBC:
-          return createDefaultOutputFile(true, InFile, "bc", OutName);
-        case BackendAction::EmitNothing:
-          return nullptr;
-        case BackendAction::EmitMCNull:
-          return createNullOutputFile();
-        case BackendAction::EmitObj:
-          return createDefaultOutputFile(true, InFile, "o", OutName);
-        case BackendAction::EmitWasm:
-          return createDefaultOutputFile(true, InFile, "wasm", OutName);
-        }
-
-        llvm_unreachable("Invalid action!");
-      };
-}
 
 CompilerInstance::CompilerInstance()
     : Invocation(std::make_unique<CompilerInvocation>()) {}
@@ -68,7 +39,7 @@ void CompilerInstance::setSourceManager(SourceManager *Value) {
 void CompilerInstance::setASTContext(ASTContext *Value) {
   Context = Value;
 
-  if (Context && hasASTConsumer())
+  if (Context && Consumer)
     getASTConsumer().Initialize(getASTContext());
 }
 
@@ -80,12 +51,10 @@ void CompilerInstance::setSema(std::unique_ptr<Sema> &&S) {
   TheSema = std::move(S);
 }
 
-void CompilerInstance::addASTConsumer(std::unique_ptr<ASTConsumer> &&Value) {
-  if (!Value)
-    return;
-  Consumer.emplace_back(std::move(Value));
+void CompilerInstance::setASTConsumer(std::unique_ptr<ASTConsumer> &&Value) {
+  Consumer = std::move(Value);
 
-  if (Context && hasASTConsumer())
+  if (Context && Consumer)
     getASTConsumer().Initialize(getASTContext());
 }
 
@@ -161,16 +130,16 @@ void CompilerInstance::createASTContext() {
 }
 
 void CompilerInstance::createSema() {
-  TheSema = std::make_unique<Sema>(getLexer());
+  TheSema =
+      std::make_unique<Sema>(getLexer(), getASTContext(), getASTConsumer());
 }
 
 std::unique_ptr<llvm::raw_pwrite_stream>
 CompilerInstance::createDefaultOutputFile(bool Binary, llvm::StringRef InFile,
-                                          llvm::StringRef Extension,
-                                          llvm::StringRef OutName) {
+                                          llvm::StringRef Extension) {
   return createOutputFile(getFrontendOpts().OutputFile, Binary,
                           /*RemoveFileOnSignal=*/true, InFile, Extension,
-                          /*UseTemporary=*/false, false, OutName);
+                          /*UseTemporary=*/false);
 }
 
 std::unique_ptr<llvm::raw_pwrite_stream>
@@ -181,13 +150,12 @@ CompilerInstance::createNullOutputFile() {
 std::unique_ptr<llvm::raw_pwrite_stream> CompilerInstance::createOutputFile(
     llvm::StringRef OutputPath, bool Binary, bool RemoveFileOnSignal,
     llvm::StringRef InFile, llvm::StringRef Extension, bool UseTemporary,
-    bool CreateMissingDirectories, llvm::StringRef OutName) {
+    bool CreateMissingDirectories) {
   std::string OutputPathName, TempPathName;
   std::error_code EC;
-  std::unique_ptr<llvm::raw_pwrite_stream> OS =
-      createOutputFile(OutputPath, EC, Binary, RemoveFileOnSignal, InFile,
-                       Extension, UseTemporary, CreateMissingDirectories,
-                       &OutputPathName, &TempPathName, OutName);
+  std::unique_ptr<llvm::raw_pwrite_stream> OS = createOutputFile(
+      OutputPath, EC, Binary, RemoveFileOnSignal, InFile, Extension,
+      UseTemporary, CreateMissingDirectories, &OutputPathName, &TempPathName);
   if (!OS) {
     // getDiagnostics().Report(diag::err_fe_unable_to_open_output) << OutputPath
     // << EC.message();
@@ -205,8 +173,7 @@ std::unique_ptr<llvm::raw_pwrite_stream> CompilerInstance::createOutputFile(
     llvm::StringRef OutputPath, std::error_code &Error, bool Binary,
     bool RemoveFileOnSignal, llvm::StringRef InFile, llvm::StringRef Extension,
     bool UseTemporary, bool CreateMissingDirectories,
-    std::string *ResultPathName, std::string *TempPathName,
-    llvm::StringRef OutName) {
+    std::string *ResultPathName, std::string *TempPathName) {
   assert((!CreateMissingDirectories || UseTemporary) &&
          "CreateMissingDirectories is only allowed when using temporary files");
 
@@ -217,10 +184,6 @@ std::unique_ptr<llvm::raw_pwrite_stream> CompilerInstance::createOutputFile(
     OutFile = "-";
   } else if (!Extension.empty()) {
     llvm::SmallString<128> Path(InFile);
-    if (OutName != "") {
-      llvm::sys::path::remove_filename(Path);
-      llvm::sys::path::append(Path, OutName);
-    }
     llvm::sys::path::replace_extension(Path, Extension);
     OutFile = Path.str();
   } else {

--- a/lib/Parse/ParseAST.cpp
+++ b/lib/Parse/ParseAST.cpp
@@ -9,22 +9,24 @@
 
 namespace soll {
 
-std::vector<std::unique_ptr<SourceUnit>>
-ParseAST(Sema &S, const InputKind &Lang, bool PrintStats) {
+void ParseAST(Sema &S, ASTConsumer &C, ASTContext &Ctx, bool PrintStats) {
+
   auto P = std::make_unique<Parser>(S.Lex, S, S.Diags);
-  switch (Lang) {
-  case InputKind::Sol: {
-    return P->parse();
-  }
-  case InputKind::Yul: {
-    std::vector<std::unique_ptr<SourceUnit>> Ret;
-    Ret.emplace_back(P->parseYul());
-    return Ret;
-  }
+  std::unique_ptr<SourceUnit> root;
+
+  switch (Ctx.getLang()) {
+  case InputKind::Sol:
+    root = P->parse();
+    break;
+  case InputKind::Yul:
+    root = P->parseYul();
+    break;
   default:
     assert(false && "unsupported language");
     __builtin_unreachable();
   }
+
+  C.HandleSourceUnit(Ctx, *root);
 }
 
 } // namespace soll

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -351,18 +351,17 @@ Parser::Parser(Lexer &TheLexer, Sema &Actions, DiagnosticsEngine &Diags)
   Tok = *TheLexer.CachedLex();
 }
 
-std::vector<std::unique_ptr<SourceUnit>> Parser::parse() {
-  std::vector<std::unique_ptr<SourceUnit>> SUs;
+std::unique_ptr<SourceUnit> Parser::parse() {
+  std::unique_ptr<SourceUnit> SU;
   {
     ParseScope SourceUnitScope{this, 0};
     std::vector<std::unique_ptr<Decl>> Nodes;
-    std::vector<std::unique_ptr<PragmaDirective>> PDs;
     const SourceLocation Begin = Tok.getLocation();
 
     while (Tok.isNot(tok::eof)) {
       switch (Tok.getKind()) {
       case tok::kw_pragma:
-        PDs.emplace_back(parsePragmaDirective());
+        Nodes.push_back(parsePragmaDirective());
         break;
       case tok::kw_import:
         ConsumeToken();
@@ -371,10 +370,6 @@ std::vector<std::unique_ptr<SourceUnit>> Parser::parse() {
       case tok::kw_library:
       case tok::kw_contract: {
         Nodes.push_back(parseContractDefinition());
-        auto SU = std::make_unique<SourceUnit>(
-            SourceRange(Begin, Tok.getLocation()), std::move(Nodes));
-        Actions.resolveType(*SU);
-        SUs.emplace_back(std::move(SU));
         break;
       }
       default:
@@ -382,8 +377,11 @@ std::vector<std::unique_ptr<SourceUnit>> Parser::parse() {
         break;
       }
     }
+    SU = std::make_unique<SourceUnit>(SourceRange(Begin, Tok.getLocation()),
+                                      std::move(Nodes));
   }
-  return SUs;
+  Actions.resolveType(*SU);
+  return SU;
 }
 
 std::unique_ptr<PragmaDirective> Parser::parsePragmaDirective() {
@@ -889,7 +887,7 @@ Parser::parseVariableDeclaration(VarDeclParserOptions const &Options,
   }
 
   if (Options.AllowEmptyName && !Tok.isAnyIdentifier()) {
-    Name = llvm::StringRef();
+    Name = llvm::StringRef("");
   } else {
     Name = Tok.getIdentifierInfo()->getName();
     ConsumeToken();

--- a/lib/Sema/Sema.cpp
+++ b/lib/Sema/Sema.cpp
@@ -8,9 +8,9 @@
 
 namespace soll {
 
-Sema::Sema(Lexer &lexer)
-    : Lex(lexer), Diags(Lex.getDiagnostics()),
-      SourceMgr(Lex.getSourceManager()) {}
+Sema::Sema(Lexer &lexer, ASTContext &ctxt, ASTConsumer &consumer)
+    : Lex(lexer), Context(ctxt), Consumer(consumer),
+      Diags(Lex.getDiagnostics()), SourceMgr(Lex.getSourceManager()) {}
 
 std::unique_ptr<FunctionDecl> Sema::CreateFunctionDecl(
     SourceRange L, llvm::StringRef Name, FunctionDecl::Visibility Vis,


### PR DESCRIPTION
This reverts commit bda2ac04193bf03c155623aec33356b80a61d7b9.
Because the current implementation violated solidity language spec.

A file should have exactly one source unit.
This source unit can contain multiple contract definitions.