### PR TITLE
[Lex] fix runtime error if there is a comment after the last token

### DIFF
--- a/lib/Lex/Lexer.cpp
+++ b/lib/Lex/Lexer.cpp
@@ -685,6 +685,10 @@ void Lexer::SkipLineComment(const char *CurPtr) {
       // If there was space between the backslash and newline, warn about it.
       if (HasSpace)
         Diag(EscapePtr, diag::backslash_newline_space);
+    } else {
+      // EOF case
+      BufferPtr = CurPtr;
+      return;
     }
 
     // Otherwise, this is a hard case.  Fall back on getAndAdvanceChar to

--- a/test/solidity/parsingTests/commemt.sol
+++ b/test/solidity/parsingTests/commemt.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// RUN: %soll %s
+contract cont1 {
+
+}
+// test s;fgks;dg 


### PR DESCRIPTION
Fix #73 